### PR TITLE
Exclude jupyter notebook from program language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+doc/*.ipynb linguist-vendored
+*.ipynb linguist-detectable=false


### PR DESCRIPTION
Created .gitattributes to exclude jupyter notebook from program language statistics.

Current:
![Screenshot 2024-11-19 at 9 26 19 AM](https://github.com/user-attachments/assets/484dcc50-77f8-4a21-a2be-dfab9a9e5c0b)

Expected:
It will show as all python.